### PR TITLE
 Prevents `/home` and `/404` pages from being indexed by Simple XML Sitemap

### DIFF
--- a/ucb_default_content.info.yml
+++ b/ucb_default_content.info.yml
@@ -9,5 +9,5 @@ dependencies:
   - pathauto
   - simple_sitemap
   - system
-version: '1.3.2'
+version: '1.4.0'
 package: CU Boulder

--- a/ucb_default_content.info.yml
+++ b/ucb_default_content.info.yml
@@ -7,6 +7,7 @@ dependencies:
   - node
   - path_alias
   - pathauto
+  - simple_sitemap
   - system
 version: '1.3.2'
 package: CU Boulder

--- a/ucb_default_content.install
+++ b/ucb_default_content.install
@@ -90,12 +90,22 @@ function _set_simplesitemap_no_index($nid) {
   // since 2019 (!!!):
   // https://www.drupal.org/project/simple_sitemap/issues/3034070
   // BEWARE OF BREAKING CHANGES to Simple XML Sitemap.
-  /** @var \Drupal\simple_sitemap\Manager\EntityManager */
-  $sitemapEntityManageer = \Drupal::service('simple_sitemap.entity_manager');
-  $sitemapEntityManageer->setEntityInstanceSettings('node', $nid, [
-    'index' => '0',
-    'priority' => '0.5',
-    'changefreq' => '',
-    'include_images' => '0',
-  ]);
+  \Drupal::database()->merge('simple_sitemap_entity_overrides')
+    ->keys([
+      'type' => 'default',
+      'entity_type' => 'node',
+      'entity_id' => $nid,
+    ])
+    ->fields([
+      'type' => 'default',
+      'entity_type' => 'node',
+      'entity_id' => $nid,
+      'inclusion_settings' => serialize([
+        'index' => '0',
+        'priority' => '0.5',
+        'changefreq' => '',
+        'include_images' => '0',
+      ]),
+    ])
+    ->execute();
 }

--- a/ucb_default_content.install
+++ b/ucb_default_content.install
@@ -86,26 +86,32 @@ function _set_simplesitemap_no_index($nid) {
   // This method may not be part of the public API but there is no other clean
   // way of doing this. Simple XML Sitemap still uses a custom
   // `simple_sitemap_entity_overrides` DB table to set these overrides. There's
-  // an issue to use a proper entity for these overrides but it's been open
-  // since 2019 (!!!):
+  // an issue to store these overrides as fields on the entity but it's been
+  // open since 2019 (!!!):
   // https://www.drupal.org/project/simple_sitemap/issues/3034070
   // BEWARE OF BREAKING CHANGES to Simple XML Sitemap.
-  \Drupal::database()->merge('simple_sitemap_entity_overrides')
-    ->keys([
-      'type' => 'default',
-      'entity_type' => 'node',
-      'entity_id' => $nid,
-    ])
-    ->fields([
-      'type' => 'default',
-      'entity_type' => 'node',
-      'entity_id' => $nid,
-      'inclusion_settings' => serialize([
-        'index' => '0',
-        'priority' => '0.5',
-        'changefreq' => '',
-        'include_images' => '0',
-      ]),
-    ])
-    ->execute();
+  $database = \Drupal::database();
+  if ($database->schema()->tableExists('simple_sitemap_entity_overrides')) {
+    $database->merge('simple_sitemap_entity_overrides')
+      ->keys([
+        'type' => 'default',
+        'entity_type' => 'node',
+        'entity_id' => $nid,
+      ])
+      ->fields([
+        'type' => 'default',
+        'entity_type' => 'node',
+        'entity_id' => $nid,
+        'inclusion_settings' => serialize([
+          'index' => '0',
+          'priority' => '0.5',
+          'changefreq' => '',
+          'include_images' => '0',
+        ]),
+      ])
+      ->execute();
+  }
+  else {
+    \Drupal::logger('ucb_default_content')->warning('Failed to set Simple XML Sitemap no index (table doesn\'t exist). Simple XML Sitemap isn\'t installed or changed something in an update.');
+  }
 }

--- a/ucb_default_content.install
+++ b/ucb_default_content.install
@@ -51,7 +51,9 @@ function _create_home_page() {
 Please click the EDIT button at the top of the screen to edit this page.',
   ]);
   $node->enforceIsNew()->save();
-  \Drupal::configFactory()->getEditable('system.site')->set('page.front', '/node/' . $node->id())->save();
+  $nid = $node->id();
+  \Drupal::configFactory()->getEditable('system.site')->set('page.front', '/node/' . $nid)->save();
+  _set_simplesitemap_no_index($nid);
 }
 
 /**
@@ -67,5 +69,33 @@ function _create_404_page() {
     'body' => 'The page you are looking for appears to have been moved, deleted, or does not exist.',
   ]);
   $node->enforceIsNew()->save();
-  \Drupal::configFactory()->getEditable('system.site')->set('page.404', '/node/' . $node->id())->save();
+  $nid = $node->id();
+  \Drupal::configFactory()->getEditable('system.site')->set('page.404', '/node/' . $nid)->save();
+  _set_simplesitemap_no_index($nid);
+}
+
+/**
+ * Sets a node to not be indexed by Simple XML Sitemap.
+ *
+ * @param string $nid
+ *   The id of the node.
+ *
+ * @internal
+ */
+function _set_simplesitemap_no_index($nid) {
+  // This method may not be part of the public API but there is no other clean
+  // way of doing this. Simple XML Sitemap still uses a custom
+  // `simple_sitemap_entity_overrides` DB table to set these overrides. There's
+  // an issue to use a proper entity for these overrides but it's been open
+  // since 2019 (!!!):
+  // https://www.drupal.org/project/simple_sitemap/issues/3034070
+  // BEWARE OF BREAKING CHANGES to Simple XML Sitemap.
+  /** @var \Drupal\simple_sitemap\Manager\EntityManager */
+  $sitemapEntityManageer = \Drupal::service('simple_sitemap.entity_manager');
+  $sitemapEntityManageer->setEntityInstanceSettings('node', $nid, [
+    'index' => '0',
+    'priority' => '0.5',
+    'changefreq' => '',
+    'include_images' => '0',
+  ]);
 }


### PR DESCRIPTION
It's a bit of a hack but it works. Resolves CuBoulder/ucb_default_content#12